### PR TITLE
Updated method name for executing commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This package provides a nice way to start docker containers and execute commands
 ````php
 $containerInstance = DockerContainer::create($imageName)->start();
 
-$process = $containerInstance->run('whoami');
+$process = $containerInstance->execute('whoami');
 
 $process->getOutput(); // returns the name of the user inside the docker container
 ````


### PR DESCRIPTION
Updated method name for executing commands in the container, from "run" to execute. Because the "run" method does not exist within the class: "Spatie \ Docker \ DockerContainer"