### PR TITLE
Permit creation of process to configure options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ vendor
 coverage
 .phpunit.result.cache
 .idea
-nbproject

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ vendor
 coverage
 .phpunit.result.cache
 .idea
+nbproject

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ You can execute multiple command in one go by passing an array.
 
 ```php
 $process = $instance->execute([$command, $anotherCommand]);
+```
 
 If you need to make adjustments to the process before running,
 you can use the `makeProcess` and run the process manually.

--- a/README.md
+++ b/README.md
@@ -154,6 +154,14 @@ You can execute multiple command in one go by passing an array.
 
 ```php
 $process = $instance->execute([$command, $anotherCommand]);
+
+If you need to make adjustments to the process before running,
+you can use the `makeProcess` and run the process manually.
+
+```php
+$process = $instance->makeProcess($command);
+$process->setTimeout(300);
+$process->run();
 ```
 
 The execute method returns an instance of [`Symfony/Process`](https://symfony.com/doc/current/components/process.html).

--- a/src/DockerContainer.php
+++ b/src/DockerContainer.php
@@ -132,6 +132,10 @@ class DockerContainer
 
         $process = Process::fromShellCommandline($command);
 
+        // increasing the timeout limit
+        $process->setTimeout(180);
+        $process->setIdleTimeout(180);
+        
         $process->run();
 
         if (! $process->isSuccessful()) {

--- a/src/DockerContainerInstance.php
+++ b/src/DockerContainerInstance.php
@@ -86,6 +86,24 @@ class DockerContainerInstance
         return $process;
     }
 
+    /**
+     * @param string|array $command
+     *
+     * @return \Symfony\Component\Process\Process
+     */
+    public function makeProcess($command): Process
+    {
+        if (is_array($command)) {
+            $command = implode(';', $command);
+        }
+
+        $fullCommand = "echo \"{$command}\" | docker exec --interactive {$this->getShortDockerIdentifier()} bash -";
+
+        $process = Process::fromShellCommandline($fullCommand);
+
+        return $process;
+    }
+
     public function addPublicKey(string $pathToPublicKey, string $pathToAuthorizedKeys = '/root/.ssh/authorized_keys'): self
     {
         $publicKeyContents = trim(file_get_contents($pathToPublicKey));

--- a/tests/FeatureTest.php
+++ b/tests/FeatureTest.php
@@ -116,15 +116,15 @@ class FeatureTest extends TestCase
         $process = $container->makeProcess('whoami');
         $process->setTimeout(300);
         $process->setIdleTimeout(90);
-        
+
         $this->assertFalse($process->isStarted());
         $this->assertFalse($process->isRunning());
         $this->assertEquals(300, $process->getTimeout());
         $this->assertEquals(90, $process->getIdleTimeout());
-        
+
         $process->run();
         $output = trim($process->getOutput());
-        
+
         $this->assertEquals('root', $output);
     }
 }

--- a/tests/FeatureTest.php
+++ b/tests/FeatureTest.php
@@ -103,4 +103,28 @@ class FeatureTest extends TestCase
 
         $this->assertEquals('root', $userName);
     }
+
+    /** @test */
+    public function process_can_be_created_and_manually_run()
+    {
+        $container = (new DockerContainer('spatie/docker'))
+            ->name('spatie_docker_test')
+            ->mapPort(4848, 22)
+            ->stopOnDestruct()
+            ->start();
+
+        $process = $container->makeProcess('whoami');
+        $process->setTimeout(300);
+        $process->setIdleTimeout(90);
+        
+        $this->assertFalse($process->isStarted());
+        $this->assertFalse($process->isRunning());
+        $this->assertEquals(300, $process->getTimeout());
+        $this->assertEquals(90, $process->getIdleTimeout());
+        
+        $process->run();
+        $output = trim($process->getOutput());
+        
+        $this->assertEquals('root', $output);
+    }
 }


### PR DESCRIPTION
Hi,

  Currently the `execute` method allows to run a command inside the container and returning a Symfony Process, however, it's not possible to adjust the process settings because it has been started inside the `execute` method.
  I might be mistaken, but even with the `Macroable` trait, we're still unable to configure options before the process start.
  This PR adds a method called `makeProcess` which will simply make everything that the `execute` method does, except running the process, so in the case the user will be able to make adjustments and manually run the process.
  Added a test to check the modifications to the process instance and also added documentation to README.
  Thanks a lot for this package.
