### PR TITLE
add support for random port mapping (-P) and with "docker port"

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,20 @@ $containerInstance = DockerContainer::create($imageName)
     ->start();
 ```
 
+You can also have docker assign the ports randomly using the `mapRandomPorts` method.
+
+```php
+$containerInstance = DockerContainer::create($imageName)
+    ->mapRandomPorts()
+    ->start();
+```
+
+You can get the list of mapped ports with the `getPorts` method on the containerInstance.
+
+```php
+$ports = $containerInstance->getPorts()
+```
+
 #### Environment variables
 
 You can set environment variables using the `setEnvironmentVariable` method. To add multiple arguments, just call `setEnvironmentVariable` multiple times.

--- a/src/DockerContainer.php
+++ b/src/DockerContainer.php
@@ -95,6 +95,11 @@ class DockerContainer
         return $this;
     }
 
+    public function mapRandomPorts(): self
+    {
+        return $this->mapPort( -1, -1 );
+    }
+
     public function mapPort(int $portOnHost, $portOnDocker): self
     {
         $this->portMappings[] = new PortMapping($portOnHost, $portOnDocker);

--- a/src/DockerContainerInstance.php
+++ b/src/DockerContainerInstance.php
@@ -62,8 +62,6 @@ class DockerContainerInstance
 
         $ports = [];
 
-        // for example: 8080/tcp -> 0.0.0.0:32903
-
         foreach ($lines as $line)  {
             $line = trim( $line );
 

--- a/src/DockerContainerInstance.php
+++ b/src/DockerContainerInstance.php
@@ -46,6 +46,37 @@ class DockerContainerInstance
         return $process;
     }
 
+    public function getPorts(): array 
+    {
+        $fullCommand = "docker port {$this->getShortDockerIdentifier()}";
+
+        $process = Process::fromShellCommandline($fullCommand);
+
+        $process->run();
+        
+        if (! $process->isSuccessful()) {
+            throw new ProcessFailedException($process);
+        }
+
+        $lines = explode( PHP_EOL, trim( $process->getOutput() ) );
+
+        $ports = [];
+
+        // for example: 8080/tcp -> 0.0.0.0:32903
+
+        foreach ($lines as $line)  {
+            $line = trim( $line );
+
+            $container = intval( $line );
+
+            $local = intval( substr( $line, 1 + strrpos( $line, ":" ) ) );
+
+            array_push( $ports, new PortMapping( $local, $container ) );
+        }
+
+        return $ports;
+    }
+
     public function getName(): string
     {
         return $this->name;

--- a/src/PortMapping.php
+++ b/src/PortMapping.php
@@ -18,10 +18,10 @@ class PortMapping
     public function __toString()
     {
         if ( -1 == $this->portOnHost || -1 == $this->portOnDocker ) {
-            return "-P ";
-        } else {
-            return "-p {$this->portOnHost}:{$this->portOnDocker}";
+            return "-P";
         }
+
+        return "-p {$this->portOnHost}:{$this->portOnDocker}";
     }
 
     public function getPortOnHost(): int

--- a/src/PortMapping.php
+++ b/src/PortMapping.php
@@ -8,7 +8,7 @@ class PortMapping
 
     private int $portOnDocker;
 
-    public function __construct(int $portOnHost, int $portOnDocker)
+    public function __construct(int $portOnHost = -1, int $portOnDocker = -1)
     {
         $this->portOnHost = $portOnHost;
 
@@ -17,6 +17,20 @@ class PortMapping
 
     public function __toString()
     {
-        return "-p {$this->portOnHost}:{$this->portOnDocker}";
+        if ( -1 == $this->portOnHost || -1 == $this->portOnDocker ) {
+            return "-P ";
+        } else {
+            return "-p {$this->portOnHost}:{$this->portOnDocker}";
+        }
+    }
+
+    public function getPortOnHost(): int
+    {
+        return $this->portOnHost;
+    }
+
+    public function getPortOnDocker(): int
+    {
+        return $this->portOnDocker;
     }
 }

--- a/tests/DockerContainerTest.php
+++ b/tests/DockerContainerTest.php
@@ -82,6 +82,16 @@ class DockerContainerTest extends TestCase
     }
 
     /** @test */
+    public function it_can_map_random_ports()
+    {
+        $command = $this->container
+            ->mapRandomPorts()
+            ->getStartCommand();
+
+        $this->assertEquals('docker run -P -d --rm spatie/docker', $command);
+    }
+
+    /** @test */
     public function it_can_set_environment_variables()
     {
         $command = $this->container
@@ -114,4 +124,6 @@ class DockerContainerTest extends TestCase
 
         $this->assertEquals('docker run -l traefik.enable=true -l foo=bar -l name=spatie -d --rm spatie/docker', $command);
     }
+
+
 }

--- a/tests/DockerContainerTest.php
+++ b/tests/DockerContainerTest.php
@@ -124,6 +124,4 @@ class DockerContainerTest extends TestCase
 
         $this->assertEquals('docker run -l traefik.enable=true -l foo=bar -l name=spatie -d --rm spatie/docker', $command);
     }
-
-
 }


### PR DESCRIPTION
Sometimes it's useful to be able to let docker handle the port mapping itself with the -P flag and then read back the mapping with "docker port {ID}".

I've tried to follow the convention and styling, but happy make changes as needed.
