### PR TITLE
Emergency fix for PR #26

### DIFF
--- a/src/DockerContainer.php
+++ b/src/DockerContainer.php
@@ -148,11 +148,20 @@ class DockerContainer
         return $this;
     }
 
+    public function getBaseCommand(): string
+    {
+        $baseCommand =  [
+            'docker',
+            ...$this->getExtraDockerOptions()
+        ];
+
+        return implode(' ', $baseCommand);
+    }
+
     public function getStartCommand(): string
     {
         $startCommand = [
-            'docker',
-            ...$this->getExtraDockerOptions(),
+            $this->getBaseCommand(),
             'run',
             ...$this->getExtraOptions(),
             $this->image
@@ -162,15 +171,13 @@ class DockerContainer
             $startCommand[] = $this->command;
         }
 
-
         return implode(' ', $startCommand);
     }
 
     public function getStopCommand(string $dockerIdentifier): string
     {
         $stopCommand = [
-            'docker',
-            ...$this->getExtraDockerOptions(),
+            $this->getBaseCommand(),
             'stop',
             $dockerIdentifier
         ];
@@ -183,8 +190,7 @@ class DockerContainer
         $execCommand = [
             "echo \"{$command}\"",
             '|',
-            'docker',
-            ...$this->getExtraDockerOptions(),
+            $this->getBaseCommand(),
             'exec',
             '--interactive',
             $dockerIdentifier,
@@ -197,8 +203,7 @@ class DockerContainer
     public function getCopyCommand(string $dockerIdentifier, string $fileOrDirectoryOnHost, string $pathInContainer): string
     {
         $copyCommand = [
-            'docker',
-            ...$this->getExtraDockerOptions(),
+            $this->getBaseCommand(),
             'cp',
             $fileOrDirectoryOnHost,
             "{$dockerIdentifier}:{$pathInContainer}"

--- a/src/DockerContainer.php
+++ b/src/DockerContainer.php
@@ -166,6 +166,47 @@ class DockerContainer
         return implode(' ', $startCommand);
     }
 
+    public function getStopCommand(string $dockerIdentifier): string
+    {
+        $stopCommand = [
+            'docker',
+            ...$this->getExtraDockerOptions(),
+            'stop',
+            $dockerIdentifier
+        ];
+
+        return implode(' ', $stopCommand);
+    }
+
+    public function getExecCommand(string $dockerIdentifier, string $command): string
+    {
+        $execCommand = [
+            "echo \"{$command}\"",
+            '|',
+            'docker',
+            ...$this->getExtraDockerOptions(),
+            'exec',
+            '--interactive',
+            $dockerIdentifier,
+            'bash -'
+        ];
+
+        return implode(' ', $execCommand);
+    }
+
+    public function getCopyCommand(string $dockerIdentifier, string $fileOrDirectoryOnHost, string $pathInContainer): string
+    {
+        $copyCommand = [
+            'docker',
+            ...$this->getExtraDockerOptions(),
+            'cp',
+            $fileOrDirectoryOnHost,
+            "{$dockerIdentifier}:{$pathInContainer}"
+        ];
+
+        return implode(' ', $copyCommand);
+    }
+
     public function start(): DockerContainerInstance
     {
         $command = $this->getStartCommand();

--- a/src/DockerContainerInstance.php
+++ b/src/DockerContainerInstance.php
@@ -37,7 +37,7 @@ class DockerContainerInstance
 
     public function stop(): Process
     {
-        $fullCommand = "docker stop {$this->getShortDockerIdentifier()}";
+        $fullCommand = $this->config->getStopCommand($this->getShortDockerIdentifier());
 
         $process = Process::fromShellCommandline($fullCommand);
 
@@ -77,7 +77,7 @@ class DockerContainerInstance
             $command = implode(';', $command);
         }
 
-        $fullCommand = "echo \"{$command}\" | docker exec --interactive {$this->getShortDockerIdentifier()} bash -";
+        $fullCommand = $this->config->getExecCommand($this->getShortDockerIdentifier(), $command);
 
         $process = Process::fromShellCommandline($fullCommand);
 
@@ -100,7 +100,10 @@ class DockerContainerInstance
 
     public function addFiles(string $fileOrDirectoryOnHost, string $pathInContainer): self
     {
-        $process = Process::fromShellCommandline("docker cp {$fileOrDirectoryOnHost} {$this->getShortDockerIdentifier()}:{$pathInContainer}");
+        $fullCommand = $this->config->getCopyCommand($this->getShortDockerIdentifier(), $fileOrDirectoryOnHost, $pathInContainer);
+
+        $process = Process::fromShellCommandline($fullCommand);
+
         $process->run();
 
         if (! $process->isSuccessful()) {

--- a/tests/DockerContainerTest.php
+++ b/tests/DockerContainerTest.php
@@ -134,4 +134,31 @@ class DockerContainerTest extends TestCase
 
         $this->assertEquals('docker run -d --rm spatie/docker whoami', $command);
     }
+
+    /** @test */
+    public function it_can_generate_stop_command()
+    {
+        $command = $this->container
+            ->getStopCommand('abcdefghijkl');
+
+        $this->assertEquals('docker stop abcdefghijkl', $command);
+    }
+
+    /** @test */
+    public function it_can_generate_exec_command()
+    {
+        $command = $this->container
+            ->getExecCommand('abcdefghijkl', 'whoami');
+
+        $this->assertEquals('echo "whoami" | docker exec --interactive abcdefghijkl bash -', $command);
+    }
+
+    /** @test */
+    public function it_can_generate_copy_command()
+    {
+        $command = $this->container
+            ->getCopyCommand('abcdefghijkl', '/home/spatie','/mnt/spatie');
+
+        $this->assertEquals('docker cp /home/spatie abcdefghijkl:/mnt/spatie', $command);
+    }
 }

--- a/tests/DockerContainerTest.php
+++ b/tests/DockerContainerTest.php
@@ -145,6 +145,16 @@ class DockerContainerTest extends TestCase
     }
 
     /** @test */
+    public function it_can_generate_stop_command_with_remote_host()
+    {
+        $command = $this->container
+            ->remoteHost('ssh://username@host')
+            ->getStopCommand('abcdefghijkl');
+
+        $this->assertEquals('docker -H ssh://username@host stop abcdefghijkl', $command);
+    }
+
+    /** @test */
     public function it_can_generate_exec_command()
     {
         $command = $this->container
@@ -154,11 +164,31 @@ class DockerContainerTest extends TestCase
     }
 
     /** @test */
+    public function it_can_generate_exec_command_with_remote_host()
+    {
+        $command = $this->container
+            ->remoteHost('ssh://username@host')
+            ->getExecCommand('abcdefghijkl', 'whoami');
+
+        $this->assertEquals('echo "whoami" | docker -H ssh://username@host exec --interactive abcdefghijkl bash -', $command);
+    }
+
+    /** @test */
     public function it_can_generate_copy_command()
     {
         $command = $this->container
             ->getCopyCommand('abcdefghijkl', '/home/spatie','/mnt/spatie');
 
         $this->assertEquals('docker cp /home/spatie abcdefghijkl:/mnt/spatie', $command);
+    }
+
+    /** @test */
+    public function it_can_generate_copy_command_with_remote_host()
+    {
+        $command = $this->container
+            ->remoteHost('ssh://username@host')
+            ->getCopyCommand('abcdefghijkl', '/home/spatie','/mnt/spatie');
+
+        $this->assertEquals('docker -H ssh://username@host cp /home/spatie abcdefghijkl:/mnt/spatie', $command);
     }
 }


### PR DESCRIPTION
This is an emergency fix for my previous PR (#26)

The `DockerContainerInstance` class also generates docker command strings. As such, using the newly added `remoteHost()` method would result in the `DockerContainerInstance` methods not properly generating a docker command to access to the remote host.

I moved all code that generates `docker` command strings to the `DockerContainer` class since it is where all of the developer-defined configs are for the docker command.

I also added additional tests for each of `DockerContainer`'s `get______Command()` methods.

No documentation changes needed.

As always, I'm happy to make any style/implementation changes that the Spatie teams sees fit~

-jeremy