### PR TITLE
Bump supported symfony/process version to ^6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": "^7.4|^8.0",
         "spatie/macroable": "^1.0",
-        "symfony/process": "^5.3"
+        "symfony/process": "^5.3|^6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.4",


### PR DESCRIPTION
This is needed to install it in a Laravel 9.0 project