### PR TITLE
Add optional args to DockerContainer class

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,18 @@ $containerInstance = DockerContainer::create($imageName)
     ->start();
 ```
 
+#### Add optional arguments
+
+If you want to add optional arguments to the `docker run` command, use `setOptionalArgs` method:
+
+```php
+$containerInstance = DockerContainer::create($imageName)
+    ->setOptionalArgs('-it', '-a')
+    ->start();
+```
+These arguments will be places after `docker run` immediately.
+
+
 #### Automatically stopping the container after PHP exists
 
 When using this package in a testing environment, it can be handy that the docker container is stopped after `__destruct` is called on it (mostly this will happen when the PHP script ends). You can enable this behaviour with the `stopOnDestruct` method.

--- a/src/DockerContainer.php
+++ b/src/DockerContainer.php
@@ -38,6 +38,8 @@ class DockerContainer
 
     public string $command = '';
 
+    public array $optionalArgs = [];
+
     public function __construct(string $image, string $name = '')
     {
         $this->image = $image;
@@ -123,6 +125,13 @@ class DockerContainer
     public function setLabel(string $labelName, string $labelValue): self
     {
         $this->labelMappings[] = new LabelMapping($labelName, $labelValue);
+
+        return $this;
+    }
+
+    public function setOptionalArgs(...$args): self
+    {
+        $this->optionalArgs = $args;
 
         return $this;
     }
@@ -236,6 +245,10 @@ class DockerContainer
     protected function getExtraOptions(): array
     {
         $extraOptions = [];
+
+        if ($this->optionalArgs) {
+            $extraOptions[] = implode(' ', $this->optionalArgs);
+        }
 
         if (count($this->portMappings)) {
             $extraOptions[] = implode(' ', $this->portMappings);

--- a/tests/DockerContainerTest.php
+++ b/tests/DockerContainerTest.php
@@ -116,6 +116,16 @@ class DockerContainerTest extends TestCase
     }
 
     /** @test */
+    public function it_can_set_optional_args()
+    {
+        $command = $this->container
+            ->setOptionalArgs('-it', '-a', '-i', '-t')
+            ->getStartCommand();
+
+        $this->assertEquals('docker run -it -a -i -t -d --rm spatie/docker', $command);
+    }
+
+    /** @test */
     public function it_can_use_remote_docker_host()
     {
         $command = $this->container


### PR DESCRIPTION
This PR aims to add ability to add optional arguments to `docker run` command through DockerContainer class.
Example:
```
$container = DockerContainer::create($imageName, $containerName)
    ->setOptionalArgs('-it', '-a')
    ->start();
```

Notes:
1. README.md updated
2. New test case added