### PR TITLE
Add function to get the "docker inspect" information

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,17 @@ Files can be added to an instance with `addFiles`.
 $instance->addFiles($fileOrDirectoryOnHost, $pathInContainer);
 ```
 
+#### Get the docker inspect information
+
+The json decoded array from the docker inspect command can be retrieved with `inspect`.
+
+```php
+$inspectArray = $instance->inspect();
+$inspectArray[0]['State']['Status']; // Running, Starting etc.
+$inspectArray[0]['RestartCount']; // Integer
+$inspectArray[0]['NetworkSettings']['IPAddress']; // 172.17.0.2
+```
+
 #### Adding other functions on the docker instance
 
 The `Spatie\Docker\ContainerInstance` class is [macroable](https://github.com/spatie/macroable). This means you can add extra functions to it.

--- a/src/DockerContainer.php
+++ b/src/DockerContainer.php
@@ -221,6 +221,17 @@ class DockerContainer
         return implode(' ', $copyCommand);
     }
 
+    public function getInspectCommand(string $dockerIdentifier): string
+    {
+        $execCommand = [
+            $this->getBaseCommand(),
+            'inspect',
+            $dockerIdentifier
+        ];
+
+        return implode(' ', $execCommand);
+    }
+
     public function start(): DockerContainerInstance
     {
         $command = $this->getStartCommand();
@@ -233,7 +244,7 @@ class DockerContainer
             throw CouldNotStartDockerContainer::processFailed($this, $process);
         }
 
-        $dockerIdentifier = $process->getOutput();
+        $dockerIdentifier = trim($process->getOutput());
 
         return new DockerContainerInstance(
             $this,

--- a/src/DockerContainerInstance.php
+++ b/src/DockerContainerInstance.php
@@ -112,4 +112,16 @@ class DockerContainerInstance
 
         return $this;
     }
+
+    public function inspect(): array
+    {
+        $fullCommand = $this->config->getInspectCommand($this->getShortDockerIdentifier());
+
+        $process = Process::fromShellCommandline($fullCommand);
+        $process->run();
+
+        $json = trim($process->getOutput());
+
+        return json_decode($json, true);
+    }
 }

--- a/tests/FeatureTest.php
+++ b/tests/FeatureTest.php
@@ -103,4 +103,18 @@ class FeatureTest extends TestCase
 
         $this->assertEquals('root', $userName);
     }
+
+    /** @test */
+    public function docker_inspect_information_can_be_retrieved()
+    {
+        $container = (new DockerContainer('spatie/docker'))
+            ->name('spatie_docker_test')
+            ->stopOnDestruct()
+            ->start();
+
+        $info = $container->inspect();
+        $this->assertEquals($container->getDockerIdentifier(), $info[0]['Id']);
+
+        $container->stop();
+    }
 }


### PR DESCRIPTION
I wanted to have the docker inspect information. This is easily possible with the macro thing, but I figured others might want this as well.

While creating a test I found that getDockerIdentifier() has the identifier with a newline at the end. The test did not like that. Fixed that as well.