### PR TITLE
Allow to specify shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,16 @@ $containerInstance = DockerContainer::create($imageName)
     ->start();
 ```
 
+#### Custom shell
+
+If the `bash` shell is not available in your docker image, you can specify an alternative shell.
+
+```php
+$containerInstance = DockerContainer::create($imageName)
+    ->shell('sh')
+    ->start();
+```
+
 #### Naming the container
 
 You can name the container by passing the name as the second argument to the constructor.

--- a/src/DockerContainer.php
+++ b/src/DockerContainer.php
@@ -18,6 +18,8 @@ class DockerContainer
 
     public bool $privileged = false;
 
+    public string $shell = 'bash';
+
     /** @var PortMapping[] */
     public array $portMappings = [];
 
@@ -76,6 +78,13 @@ class DockerContainer
     public function privileged(bool $privileged = true): self
     {
         $this->privileged = $privileged;
+
+        return $this;
+    }
+
+    public function shell(string $shell): self
+    {
+        $this->shell = $shell;
 
         return $this;
     }
@@ -203,7 +212,8 @@ class DockerContainer
             'exec',
             '--interactive',
             $dockerIdentifier,
-            'bash -',
+            $this->shell,
+            '-',
         ];
 
         return implode(' ', $execCommand);

--- a/tests/DockerContainerTest.php
+++ b/tests/DockerContainerTest.php
@@ -184,6 +184,16 @@ class DockerContainerTest extends TestCase
     }
 
     /** @test */
+    public function it_can_generate_exec_command_with_custom_shell()
+    {
+        $command = $this->container
+            ->shell('sh')
+            ->getExecCommand('abcdefghijkl', 'whoami');
+
+        $this->assertEquals('echo "whoami" | docker exec --interactive abcdefghijkl sh -', $command);
+    }
+
+    /** @test */
     public function it_can_generate_copy_command()
     {
         $command = $this->container


### PR DESCRIPTION
Hello,

the `execute` Command relys that `bash` is available in the docker containers. But not all docker images have bash. For example the `mailhog/mailhog` image only has `sh` available.

This method allows to specify the shell, with `bash` being the default one.

I've added a small test and readme section. If there is anything else I need to do, please let me know.

And thanks for your awesome work!