### PR TITLE
Allow to have "string" ports

### DIFF
--- a/src/DockerContainer.php
+++ b/src/DockerContainer.php
@@ -110,7 +110,10 @@ class DockerContainer
         return $this;
     }
 
-    public function mapPort(int $portOnHost, $portOnDocker): self
+    /**
+     * @param int|string $portOnHost
+     */
+    public function mapPort($portOnHost, int $portOnDocker): self
     {
         $this->portMappings[] = new PortMapping($portOnHost, $portOnDocker);
 

--- a/src/PortMapping.php
+++ b/src/PortMapping.php
@@ -4,11 +4,15 @@ namespace Spatie\Docker;
 
 class PortMapping
 {
-    private int $portOnHost;
+    /** @var int|string */
+    private $portOnHost;
 
     private int $portOnDocker;
 
-    public function __construct(int $portOnHost, int $portOnDocker)
+    /**
+     * @param int|string $portOnHost
+     */
+    public function __construct($portOnHost, int $portOnDocker)
     {
         $this->portOnHost = $portOnHost;
 

--- a/tests/DockerContainerTest.php
+++ b/tests/DockerContainerTest.php
@@ -82,6 +82,17 @@ class DockerContainerTest extends TestCase
     }
 
     /** @test */
+    public function it_can_map_string_ports()
+    {
+        $command = $this->container
+            ->mapPort('127.0.0.1:4848', 22)
+            ->mapPort('0.0.0.0:9000', 21)
+            ->getStartCommand();
+
+        $this->assertEquals('docker run -p 127.0.0.1:4848:22 -p 0.0.0.0:9000:21 -d --rm spatie/docker', $command);
+    }
+
+    /** @test */
     public function it_can_set_environment_variables()
     {
         $command = $this->container


### PR DESCRIPTION
Heyho me again 👋 

Currently it is only possible to provide integer ports to docker (because of the typehint). But other valid ports can contain the ip address / subnet.

For example, those are all valid ports:
```
127:0.0.1:8000
8000
0.0.0.0:8000
```

So, I've removed the `int` typehint and replaced it with a docblock, which allows both string and int. When this package drops PHP 7.4 support in the future, the docblock can be replaced with a union type:

I've added another test to verify that everything is still working. Since integers still work fine, I believe this isn't a breaking change. If you need anything else for die PR, feel free to ask 👍 

Thank you!