### PR TITLE
Add class to manage docker networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,83 @@ $containerInstance = DockerContainer::create($imageName)->start();
 $containerInstance->whoAmI(); // returns of name of user in the docker container
 ````
 
+### Manage Docker Networks
+
+#### Creating a docker network
+
+To create a docker network, use the `DockerNetwork` class.
+
+```php
+$network = new DockerNetwork('my-network');
+$network->create();
+```
+
+#### Add optional arguments
+
+If you want to add optional arguments to the `docker network create` command, use `setOptionalArgs` method:
+
+```php
+$network = (new DockerNetwork($networkName))
+    ->setOptionalArgs('--ipv6', '--internal')
+    ->create();
+```
+These arguments will be places after `docker network create` immediately.
+
+#### Specify a remote docker host for execution
+
+You can set the host used for creating the network. The `docker` command line accepts a daemon socket string. To connect to a remote docker host via ssh, use the syntax `ssh://username@hostname`. Note that the proper SSH keys will already need to be configured for this work.
+
+```php
+$network = (new DockerNetwork($networkName))
+    ->remoteHost('ssh://username@hostname')
+    ->create();
+```
+
+#### Specify an alternative network driver
+
+By default new networks will be created with the bridge driver. The `driver` method gives the ability to override that.
+
+```php
+$network = (new DockerNetwork($networkName))
+    ->driver('macvlan')
+    ->create();
+```
+
+#### Getting the create command string
+
+You can get the string that will be executed when a network is created with the `getCreateCommand` function
+
+```php
+// returns "docker network create --driver bridge network-name"
+(new DockerNetwork($networkName))->getCreateCommand();
+```
+
+#### Removing networks
+
+You can also remove existing networks, using the `remove` command.
+
+```php
+(new DockerNetwork($networkName))->remove();
+```
+
+#### Getting the remove command string
+
+You can get the string that will be executed when a network is removed with the `getRemoveCommand` function
+
+```php
+// returns "docker network rm network-name"
+(new DockerNetwork($networkName))->getRemoveCommand();
+```
+
+#### Check if a network exists
+
+Using the `exists` method, you can check if a network already exists.
+
+```php
+// return true, if the network exists. Otherwise false
+(new DockerNetwork($networkName))->exists();
+```
+
 ### Testing
 
 Before running the tests for the first time, you must build the `spatie/docker` container with:

--- a/src/DockerNetwork.php
+++ b/src/DockerNetwork.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace Spatie\Docker;
+
+use Spatie\Docker\Exceptions\CouldNotCreateDockerNetwork;
+use Spatie\Docker\Exceptions\CouldNotRemoveDockerNetwork;
+use Symfony\Component\Process\Process;
+
+class DockerNetwork
+{
+    public string $name;
+
+    public string $driver = 'bridge';
+
+    public string $remoteHost;
+
+    public array $optionalArgs = [];
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    public function name(string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function driver(string $driver): self
+    {
+        $this->driver = $driver;
+
+        return $this;
+    }
+
+    public function setOptionalArgs(string ...$args): self
+    {
+        $this->optionalArgs = $args;
+
+        return $this;
+    }
+
+    public function remoteHost(string $remoteHost): self
+    {
+        $this->remoteHost = $remoteHost;
+
+        return $this;
+    }
+
+    public function getBaseCommand(): string
+    {
+        $baseCommand = [
+            'docker',
+            ...$this->getExtraDockerOptions(),
+            'network'
+        ];
+
+        return implode(' ', $baseCommand);
+    }
+
+    public function getCreateCommand(): string
+    {
+        $createCommand = [
+            $this->getBaseCommand(),
+            'create',
+            ...$this->getExtraOptions(),
+            $this->name
+        ];
+
+        return implode(' ', $createCommand);
+    }
+
+    public function getRemoveCommand(): string
+    {
+        $removeCommand = [
+            $this->getBaseCommand(),
+            'rm',
+            $this->name
+        ];
+
+        return implode(' ', $removeCommand);
+    }
+
+    public function getExistsCommand(): string
+    {
+        $existsCommand = [
+            $this->getBaseCommand(),
+            'inspect',
+            $this->name
+        ];
+
+        return implode(' ', $existsCommand);
+    }
+
+    public function create(): self
+    {
+        $command = $this->getCreateCommand();
+
+        $process = Process::fromShellCommandline($command);
+        $process->run();
+
+        if (!$process->isSuccessful()) {
+            throw CouldNotCreateDockerNetwork::processFailed($this, $process);
+        }
+
+        return $this;
+    }
+
+    public function remove(): self
+    {
+        $command = $this->getRemoveCommand();
+
+        $process = Process::fromShellCommandline($command);
+        $process->run();
+
+        if (!$process->isSuccessful()) {
+            throw CouldNotRemoveDockerNetwork::processFailed($this, $process);
+        }
+
+        return $this;
+    }
+
+    public function exists(): bool
+    {
+        $command = $this->getExistsCommand();
+
+        $process = Process::fromShellCommandline($command);
+        $process->run();
+
+        return $process->isSuccessful();
+    }
+
+    protected function getExtraOptions(): array
+    {
+        $extraOptions = [];
+
+        if ($this->optionalArgs) {
+            $extraOptions[] = implode(' ', $this->optionalArgs);
+        }
+
+        $extraOptions[] = '--driver ' . $this->driver;
+
+        return $extraOptions;
+    }
+
+    protected function getExtraDockerOptions(): array
+    {
+        $extraDockerOptions = [];
+
+        if (!empty($this->remoteHost)) {
+            $extraDockerOptions[] = "-H {$this->remoteHost}";
+        }
+
+        return $extraDockerOptions;
+    }
+}

--- a/src/Exceptions/CouldNotCreateDockerNetwork.php
+++ b/src/Exceptions/CouldNotCreateDockerNetwork.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Spatie\Docker\Exceptions;
+
+use Exception;
+use Spatie\Docker\DockerContainer;
+use Spatie\Docker\DockerNetwork;
+use Symfony\Component\Process\Process;
+
+class CouldNotCreateDockerNetwork extends Exception
+{
+    public static function processFailed(DockerNetwork $network, Process $process)
+    {
+        return new static("Could not create docker network `{$network->name}`. Process output: `{$process->getErrorOutput()}`");
+    }
+}

--- a/src/Exceptions/CouldNotRemoveDockerNetwork.php
+++ b/src/Exceptions/CouldNotRemoveDockerNetwork.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Spatie\Docker\Exceptions;
+
+use Exception;
+use Spatie\Docker\DockerContainer;
+use Spatie\Docker\DockerNetwork;
+use Symfony\Component\Process\Process;
+
+class CouldNotRemoveDockerNetwork extends Exception
+{
+    public static function processFailed(DockerNetwork $network, Process $process)
+    {
+        return new static("Could not remove docker network `{$network->name}`. Process output: `{$process->getErrorOutput()}`");
+    }
+}

--- a/tests/DockerNetworkTest.php
+++ b/tests/DockerNetworkTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Spatie\Docker\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Spatie\Docker\DockerContainer;
+use Spatie\Docker\DockerNetwork;
+
+class DockerNetworkTest extends TestCase
+{
+    private DockerNetwork $network;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->network = new DockerNetwork('spatie-docker');
+    }
+
+    /** @test */
+    public function it_can_be_created()
+    {
+        $command = $this->network
+            ->getCreateCommand();
+
+        $this->assertEquals('docker network create --driver bridge spatie-docker', $command);
+    }
+
+    /** @test **/
+    public function it_can_change_the_name()
+    {
+        $command = $this->network
+            ->name('my-name')
+            ->getCreateCommand();
+
+        $this->assertEquals('docker network create --driver bridge my-name', $command);
+    }
+
+    /** @test **/
+    public function it_can_change_the_driver()
+    {
+        $command = $this->network
+            ->driver('macvlan')
+            ->getCreateCommand();
+
+        $this->assertEquals('docker network create --driver macvlan spatie-docker', $command);
+    }
+
+    /** @test */
+    public function it_can_set_optional_args()
+    {
+        $command = $this->network
+            ->setOptionalArgs('--ipv6', '--internal')
+            ->getCreateCommand();
+
+        $this->assertEquals('docker network create --ipv6 --internal --driver bridge spatie-docker', $command);
+    }
+
+    /** @test */
+    public function it_can_use_remote_docker_host()
+    {
+        $command = $this->network
+            ->remoteHost('ssh://username@host')
+            ->getCreateCommand();
+
+        $this->assertEquals('docker -H ssh://username@host network create --driver bridge spatie-docker', $command);
+    }
+
+    /** @test */
+    public function it_can_generate_remove_command()
+    {
+        $command = $this->network
+            ->getRemoveCommand();
+
+        $this->assertEquals('docker network rm spatie-docker', $command);
+    }
+
+    /** @test */
+    public function it_can_generate_remove_command_with_remote_host()
+    {
+        $command = $this->network
+            ->remoteHost('ssh://username@host')
+            ->getRemoveCommand();
+
+        $this->assertEquals('docker -H ssh://username@host network rm spatie-docker', $command);
+    }
+
+    /** @test */
+    public function it_can_generate_exists_command()
+    {
+        $command = $this->network
+            ->getExistsCommand();
+
+        $this->assertEquals('docker network inspect spatie-docker', $command);
+    }
+
+    /** @test */
+    public function it_can_generate_exists_command_with_remote_host()
+    {
+        $command = $this->network
+            ->remoteHost('ssh://username@host')
+            ->getExistsCommand();
+
+        $this->assertEquals('docker -H ssh://username@host network inspect spatie-docker', $command);
+    }
+}


### PR DESCRIPTION
Heyho,

this is my first draft for a class which manages docker networks. With this you can create, remove and check for existance.

I've tried to let the two classes feel quite similar.

Usage:
```
$network = new DockerNetwork('network-name');

$network->driver('macvlan'); // Allows you to change the driver of the network

$network->create(); // Creates it
$network->remove(); // Removes it
$network->exists(); // Return a bool, whether the network exists
```

Of course, all of the regular stuff, like changing remote host or setting optional arguments are still in there. Maybe we could refactor it, so that we have a trait which holds the same variables / methods which both uses. But I didn't want to do to much work, in case you don't want this in your package :-)

What I removed though is the ability to create a class instance with a static method, like `DockerNetwork::create(……)`. The problem is, the `create` method creates the real network in docker and I couldn't come up with a better name for it.

Do you have any ideas?

Thanks in advance! If you don't want this in your package or if I need to something else, please let me know. I've added the README sections and tests.

Related to #18 