### PR TITLE
Allow to specify a docker network

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,16 @@ $containerInstance = DockerContainer::create($imageName)
     ->start();
 ```
 
+#### Attaching a network to the container
+
+If you want to attach the container to a docker network, use `setNetwork` method:
+
+```php
+$containerInstance = DockerContainer::create($imageName)
+    ->network('my-network')
+    ->start();
+```
+
 #### Specify a remote docker host for execution
 
 You can set the host used for executing the container. The `docker` command line accepts a daemon socket string. To connect to a remote docker host via ssh, use the syntax `ssh://username@hostname`. Note that the proper SSH keys will already need to be configured for this work.

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ $containerInstance = DockerContainer::create($imageName)
 
 #### Attaching a network to the container
 
-If you want to attach the container to a docker network, use `setNetwork` method:
+If you want to attach the container to a docker network, use `network` method:
 
 ```php
 $containerInstance = DockerContainer::create($imageName)

--- a/src/DockerContainer.php
+++ b/src/DockerContainer.php
@@ -20,6 +20,8 @@ class DockerContainer
 
     public string $shell = 'bash';
 
+    public ?string $network = null;
+
     /** @var PortMapping[] */
     public array $portMappings = [];
 
@@ -85,6 +87,13 @@ class DockerContainer
     public function shell(string $shell): self
     {
         $this->shell = $shell;
+
+        return $this;
+    }
+
+    public function network(?string $network): self
+    {
+        $this->network = $network;
 
         return $this;
     }
@@ -304,6 +313,10 @@ class DockerContainer
 
         if ($this->cleanUpAfterExit) {
             $extraOptions[] = '--rm';
+        }
+
+        if ($this->network) {
+            $extraOptions[] = '--network ' . $this->network;
         }
 
         return $extraOptions;

--- a/src/DockerContainer.php
+++ b/src/DockerContainer.php
@@ -91,7 +91,7 @@ class DockerContainer
         return $this;
     }
 
-    public function network(?string $network): self
+    public function network(string $network): self
     {
         $this->network = $network;
 

--- a/tests/DockerContainerTest.php
+++ b/tests/DockerContainerTest.php
@@ -137,6 +137,16 @@ class DockerContainerTest extends TestCase
     }
 
     /** @test */
+    public function it_can_set_network()
+    {
+        $command = $this->container
+            ->network('my-network')
+            ->getStartCommand();
+
+        $this->assertEquals('docker run -d --rm --network my-network spatie/docker', $command);
+    }
+
+    /** @test */
     public function it_can_use_remote_docker_host()
     {
         $command = $this->container


### PR DESCRIPTION
Ahoy,

this is a simple method, which allows us to set the network of the container on startup. It can be used with #42, but it is unrelated to it, hence the second PR.

Thanks in advance!