### PR TITLE
Adds support for commands to be passed with start/run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,17 @@ $containerInstance = DockerContainer::create($imageName)
     ->start();
 ```
 
+#### Adding Commands
+
+You can add commands using the `setCommands` method.
+
+```php
+$containerInstance = DockerContainer::create($imageName)
+    ->setCommands('--api.insecure=true', '--providers.docker=true')
+    ->start();
+```
+These commands will be placed at the end of to the `docker run` command.
+
 #### Add optional arguments
 
 If you want to add optional arguments to the `docker run` command, use `setOptionalArgs` method:
@@ -154,7 +165,7 @@ $containerInstance = DockerContainer::create($imageName)
     ->setOptionalArgs('-it', '-a')
     ->start();
 ```
-These arguments will be places after `docker run` immediately.
+These arguments will be placed after `docker run` immediately.
 
 
 #### Automatically stopping the container after PHP exists

--- a/src/DockerContainer.php
+++ b/src/DockerContainer.php
@@ -44,6 +44,8 @@ class DockerContainer
 
     public array $optionalArgs = [];
 
+    public array $commands = [];
+
     public function __construct(string $image, string $name = '')
     {
         $this->image = $image;
@@ -157,6 +159,13 @@ class DockerContainer
         return $this;
     }
 
+    public function setCommands(...$args): self
+    {
+        $this->commands = $args;
+
+        return $this;
+    }
+
     public function stopOnDestruct(bool $stopOnDestruct = true): self
     {
         $this->stopOnDestruct = $stopOnDestruct;
@@ -195,6 +204,7 @@ class DockerContainer
             'run',
             ...$this->getExtraOptions(),
             $this->image,
+            ...$this->commands,
         ];
 
         if ($this->command !== '') {

--- a/tests/DockerContainerTest.php
+++ b/tests/DockerContainerTest.php
@@ -60,7 +60,7 @@ class DockerContainerTest extends TestCase
         $this->assertEquals('docker run -d spatie/docker', $command);
     }
 
-    /** @test **/
+    /** @test * */
     public function it_can_be_named()
     {
         $command = $this->container
@@ -111,7 +111,8 @@ class DockerContainerTest extends TestCase
             ->setVolume('/data', '/data')
             ->getStartCommand();
 
-        $this->assertEquals('docker run -v /on/my/host:/on/my/container -v /data:/data -d --rm spatie/docker', $command);
+        $this->assertEquals('docker run -v /on/my/host:/on/my/container -v /data:/data -d --rm spatie/docker',
+            $command);
     }
 
     /** @test */
@@ -123,7 +124,8 @@ class DockerContainerTest extends TestCase
             ->setLabel('name', 'spatie')
             ->getStartCommand();
 
-        $this->assertEquals('docker run -l traefik.enable=true -l foo=bar -l name=spatie -d --rm spatie/docker', $command);
+        $this->assertEquals('docker run -l traefik.enable=true -l foo=bar -l name=spatie -d --rm spatie/docker',
+            $command);
     }
 
     /** @test */
@@ -134,6 +136,16 @@ class DockerContainerTest extends TestCase
             ->getStartCommand();
 
         $this->assertEquals('docker run -it -a -i -t -d --rm spatie/docker', $command);
+    }
+
+    /** @test */
+    public function it_can_set_commands()
+    {
+        $command = $this->container
+            ->setCommands('--api.insecure=true', '--entrypoints.web.address=:80')
+            ->getStartCommand();
+
+        $this->assertEquals('docker run -d --rm spatie/docker --api.insecure=true --entrypoints.web.address=:80', $command);
     }
 
     /** @test */
@@ -201,7 +213,8 @@ class DockerContainerTest extends TestCase
             ->remoteHost('ssh://username@host')
             ->getExecCommand('abcdefghijkl', 'whoami');
 
-        $this->assertEquals('echo "whoami" | docker -H ssh://username@host exec --interactive abcdefghijkl bash -', $command);
+        $this->assertEquals('echo "whoami" | docker -H ssh://username@host exec --interactive abcdefghijkl bash -',
+            $command);
     }
 
     /** @test */


### PR DESCRIPTION
Adds support for passing commands after the image name.
Example of such commands are `--log.level=INFO --api.insecure=true` in the following run:

`docker run -p 8080:8080 traefik:v2.3 --log.level=INFO --api.insecure=true`

Example of a docker-compose.yml file section of such commands:

```yml
services:
  traefik:
    image: "traefik:v2.9"
    [...]
    command:
      - "--api.insecure=true"
      - "--providers.docker=true"
      - "--providers.docker.exposedbydefault=false"
      - "--entrypoints.web.address=:80"
    ports:
        [...]
```