### PR TITLE
updated Github shield link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Manage docker containers with PHP
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/spatie/docker.svg?style=flat-square)](https://packagist.org/packages/spatie/docker)
-[![GitHub Tests Action Status](https://img.shields.io/github/workflow/status/spatie/docker/run-tests?label=tests)](https://github.com/spatie/docker/actions?query=workflow%3Arun-tests+branch%3Amaster)
+[![GitHub Tests Action Status](https://img.shields.io/github/actions/workflow/status/spatie/docker/run-tests.yml?label=tests)](https://github.com/spatie/docker/actions?query=workflow%3Arun-tests+branch%3Amaster)
 [![Total Downloads](https://img.shields.io/packagist/dt/spatie/docker.svg?style=flat-square)](https://packagist.org/packages/spatie/docker)
 
 This package provides a nice way to start docker containers and execute commands on them.


### PR DESCRIPTION
This pull request corrects the link for GitHub Tests Action Status to adhere to the new format as reported here: [https://github.com/badges/shields/issues/8671](https://github.com/badges/shields/issues/8671).