### PR TITLE
Update Macroable Dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "spatie/macroable": "^1.0",
+        "spatie/macroable": "^1.0|^2.0",
         "symfony/process": "^5.3|^6.0"
     },
     "require-dev": {


### PR DESCRIPTION
Using this as dev dependency in a package generated with [spatie/package-skeleton-laravel](https://github.com/spatie/package-skeleton-laravel) which installs latest [spatie/macroable](https://github.com/spatie/macroable). Installing [spatie/docker](https://github.com/spatie/docker)  requires to delete `composer.lock` file so that `spatie/macroable` can be downgraded.