### PR TITLE
Support changing `execute` timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,16 @@ You can get the string that will be executed when a container is started with th
 DockerContainer::create($imageName)->getStartCommand();
 ```
 
+#### Changing the start command timeout
+
+You can change the timeout for the start command with the `setStartCommandTimeout` function _(the default is 60s)_.
+
+```php
+$containerInstance = DockerContainer::create($imageName)
+    ->setStartCommandTimeout(120)
+    ->start();
+```
+
 ### Available methods on the docker container instance
 
 #### Executing a command

--- a/README.md
+++ b/README.md
@@ -230,6 +230,12 @@ You can execute multiple command in one go by passing an array.
 $process = $instance->execute([$command, $anotherCommand]);
 ```
 
+To change the process timeout you can pass a second parameter to the `execute` method _(the default is 60s)_.
+
+```php
+$process = $instance->execute($command, 3600);
+```
+
 The execute method returns an instance of [`Symfony/Process`](https://symfony.com/doc/current/components/process.html).
 
 You can check if your command ran successfully using the `isSuccessful` $method

--- a/src/DockerContainer.php
+++ b/src/DockerContainer.php
@@ -46,6 +46,8 @@ class DockerContainer
 
     public array $commands = [];
 
+    protected float $startCommandTimeout = 60;
+
     public function __construct(string $image, string $name = '')
     {
         $this->image = $image;
@@ -270,6 +272,8 @@ class DockerContainer
 
         $process = Process::fromShellCommandline($command);
 
+        $process->setTimeout($this->startCommandTimeout);
+
         $process->run();
 
         if (! $process->isSuccessful()) {
@@ -283,6 +287,17 @@ class DockerContainer
             $dockerIdentifier,
             $this->name,
         );
+    }
+
+    public function setStartCommandTimeout(float $timeout): self
+    {
+        $this->startCommandTimeout = $timeout;
+        return $this;
+    }
+
+    public function getStartCommandTimeout(): float
+    {
+        return $this->startCommandTimeout;
     }
 
     protected function getExtraOptions(): array

--- a/src/DockerContainerInstance.php
+++ b/src/DockerContainerInstance.php
@@ -68,10 +68,11 @@ class DockerContainerInstance
 
     /**
      * @param string|array $command
+     * @param float|null $timeout
      *
      * @return \Symfony\Component\Process\Process
      */
-    public function execute($command): Process
+    public function execute($command, ?float $timeout = 60): Process
     {
         if (is_array($command)) {
             $command = implode(';', $command);
@@ -80,6 +81,8 @@ class DockerContainerInstance
         $fullCommand = $this->config->getExecCommand($this->getShortDockerIdentifier(), $command);
 
         $process = Process::fromShellCommandline($fullCommand);
+
+        $process->setTimeout($timeout);
 
         $process->run();
 

--- a/tests/DockerContainerInstanceTest.php
+++ b/tests/DockerContainerInstanceTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 use Spatie\Docker\DockerContainer;
 use Spatie\Docker\DockerContainerInstance;
 

--- a/tests/DockerContainerInstanceTest.php
+++ b/tests/DockerContainerInstanceTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+use Spatie\Docker\DockerContainer;
+use Spatie\Docker\DockerContainerInstance;
+
+beforeEach(function () {
+    $this->containerInstance = new DockerContainerInstance(new DockerContainer('spatie/docker'), '1234', 'test');
+});
+
+it('defaults process timeout to 60s', function () {
+    $process = $this->containerInstance->execute('whoami');
+
+    expect($process->getTimeout())->toEqual(60);
+});
+
+it('can set a custom process timeout', function () {
+    $process = $this->containerInstance->execute('whoami', 3600);
+
+    expect($process->getTimeout())->toEqual(3600);
+});

--- a/tests/DockerContainerTest.php
+++ b/tests/DockerContainerTest.php
@@ -188,3 +188,14 @@ it('can generate copy command with remote host', function () {
 
     expect($command)->toEqual('docker -H ssh://username@host cp /home/spatie abcdefghijkl:/mnt/spatie');
 });
+
+it('has a default start command timeout of 60s', function () {
+    expect($this->container->getStartCommandTimeout())->toEqual(60);
+});
+
+it('can set a custom start command timeout', function () {
+    $return = $this->container->setStartCommandTimeout(3600);
+
+    expect($this->container->getStartCommandTimeout())->toEqual(3600);
+    expect($return)->toEqual($this->container);
+});


### PR DESCRIPTION
- Added an optional second parameter to the `execute()` method that enables a custom timeout to be set.
- Added `setStartCommandTimeout()` to enable custom timeout to be set on the start command

Test cases added and README updated.