### PR TITLE
add custom docker bin option

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,16 @@ $containerInstance = DockerContainer::create($imageName)
     ->start();
 ```
 
+#### Custom docker binary
+
+If the `docker` binary is not globally available, you can specify the exact path.
+
+```php
+$containerInstance = DockerContainer::create($imageName)
+    ->dockerBin('/usr/local/bin/docker')
+    ->start();
+```
+
 #### Naming the container
 
 You can name the container by passing the name as the second argument to the constructor.

--- a/src/DockerContainer.php
+++ b/src/DockerContainer.php
@@ -18,6 +18,8 @@ class DockerContainer
 
     public bool $privileged = false;
 
+    public string $dockerBin = 'docker';
+
     public string $shell = 'bash';
 
     public ?string $network = null;
@@ -84,6 +86,13 @@ class DockerContainer
     public function privileged(bool $privileged = true): self
     {
         $this->privileged = $privileged;
+
+        return $this;
+    }
+
+    public function dockerBin(string $dockerBin): self
+    {
+        $this->dockerBin = $dockerBin;
 
         return $this;
     }
@@ -192,7 +201,7 @@ class DockerContainer
     public function getBaseCommand(): string
     {
         $baseCommand = [
-            'docker',
+            $this->dockerBin,
             ...$this->getExtraDockerOptions(),
         ];
 

--- a/tests/DockerContainerTest.php
+++ b/tests/DockerContainerTest.php
@@ -174,6 +174,14 @@ it('can generate exec command with custom shell', function () {
     expect($command)->toEqual('echo "whoami" | docker exec --interactive abcdefghijkl sh -');
 });
 
+it('can generate exec command with custom docker bin', function () {
+    $command = $this->container
+        ->dockerBin('/usr/local/bin/docker')
+        ->getExecCommand('abcdefghijkl', 'whoami');
+
+    expect($command)->toEqual('echo "whoami" | /usr/local/bin/docker exec --interactive abcdefghijkl bash -');
+});
+
 it('can generate copy command', function () {
     $command = $this->container
         ->getCopyCommand('abcdefghijkl', '/home/spatie', '/mnt/spatie');


### PR DESCRIPTION
This PR adds the option to specify a custom docker bin path, which in certain cases is required if docker is not available at any path defined in $PATH